### PR TITLE
Update parser class to use a static require

### DIFF
--- a/src/logcat/parser.coffee
+++ b/src/logcat/parser.coffee
@@ -1,8 +1,10 @@
 {EventEmitter} = require 'events'
+parser = require "./parser/binary"
 
 class Parser extends EventEmitter
   @get: (type) ->
-    parser = require "./parser/#{type}"
+    if type !== 'binary'
+      throw new Error "Unknown parser type #{type}"
     new parser()
 
   parse: ->


### PR DESCRIPTION
The `long` parser format was removed which makes this logic redundant. The use of passing an expression to `require` made it impossible to use `adbkit-logcat` with a bundler.